### PR TITLE
[MET-251] options matching new binaries for alert managaer

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -212,9 +212,9 @@ class prometheus::alertmanager (
       mode   => '0755',
     }
 
-    $options = "-config.file=${prometheus::alertmanager::config_file} -storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} --storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
   } else {
-    $options = "-config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
   }
 
   prometheus::daemon { 'alertmanager':


### PR DESCRIPTION
- Enabling service to be started using right configuration options:

` from -config-file to --config-file`