### PR TITLE
Increase max open files to 65k

### DIFF
--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -17,6 +17,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
 RestartSec=42s
+LimitNOFILE=65000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Prometheus was hitting the soft limit of 1024. Sometimes couldn't start. Increased max open files for the prometheus systemd process to 65000